### PR TITLE
[FEAT] - Base Input System

### DIFF
--- a/Assets/Input.meta
+++ b/Assets/Input.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ddfbd110ca4532242981e4fe058b5fbc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Input/InputSystem.inputsettings.asset
+++ b/Assets/Input/InputSystem.inputsettings.asset
@@ -1,0 +1,28 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c46f07b5ed07e4e92aa78254188d3d10, type: 3}
+  m_Name: InputSystem.inputsettings
+  m_EditorClassIdentifier: 
+  m_SupportedDevices:
+  - Gamepad
+  - Keyboard
+  m_UpdateMode: 1
+  m_CompensateForScreenOrientation: 1
+  m_FilterNoiseOnCurrent: 0
+  m_DefaultDeadzoneMin: 0.25
+  m_DefaultDeadzoneMax: 0.925
+  m_DefaultButtonPressPoint: 0.5
+  m_DefaultTapTime: 0.2
+  m_DefaultSlowTapTime: 0.5
+  m_DefaultHoldTime: 0.4
+  m_TapRadius: 5
+  m_MultiTapDelayTime: 0.75

--- a/Assets/Input/InputSystem.inputsettings.asset.meta
+++ b/Assets/Input/InputSystem.inputsettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 490d09f96a57bf643840772a85a17873
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Input/PlayerInput.cs
+++ b/Assets/Input/PlayerInput.cs
@@ -1,0 +1,319 @@
+// GENERATED AUTOMATICALLY FROM 'Assets/Input/PlayerInput.inputactions'
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Utilities;
+
+public class @PlayerInput : IInputActionCollection, IDisposable
+{
+    public InputActionAsset asset { get; }
+    public @PlayerInput()
+    {
+        asset = InputActionAsset.FromJson(@"{
+    ""name"": ""PlayerInput"",
+    ""maps"": [
+        {
+            ""name"": ""Player"",
+            ""id"": ""36e029b3-1b1a-433b-8e49-434a71c5cabf"",
+            ""actions"": [
+                {
+                    ""name"": ""Move"",
+                    ""type"": ""Value"",
+                    ""id"": ""2b152bf1-0e2b-46a2-9880-4c96c9881a59"",
+                    ""expectedControlType"": ""Vector2"",
+                    ""processors"": """",
+                    ""interactions"": """"
+                },
+                {
+                    ""name"": ""Jump"",
+                    ""type"": ""Button"",
+                    ""id"": ""14049dc8-85b7-41c6-aeb4-8d118b697b33"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": """"
+                },
+                {
+                    ""name"": ""Dash"",
+                    ""type"": ""Button"",
+                    ""id"": ""59c3dfb9-cbc2-4900-b552-6d02dc55acac"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": """"
+                }
+            ],
+            ""bindings"": [
+                {
+                    ""name"": """",
+                    ""id"": ""618146dd-3f6e-44c4-bdd2-26b20f03665b"",
+                    ""path"": ""<Gamepad>/leftStick"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Gamepad"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""7b7d8eee-69c4-4456-9535-d41344cf6824"",
+                    ""path"": ""<Joystick>/stick"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Gamepad"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""Arrows"",
+                    ""id"": ""d14f03b1-52bc-4d72-9983-7700e1fcc36a"",
+                    ""path"": ""2DVector"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Move"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""up"",
+                    ""id"": ""b0568dd2-7771-4df9-b7c7-7780b9b0d015"",
+                    ""path"": ""<Keyboard>/upArrow"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""down"",
+                    ""id"": ""5f05f417-396c-4014-89b8-6ecb828cfa4f"",
+                    ""path"": ""<Keyboard>/downArrow"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""left"",
+                    ""id"": ""9465263f-c3ac-42e0-8158-df9bed5b0023"",
+                    ""path"": ""<Keyboard>/leftArrow"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""right"",
+                    ""id"": ""61601d4f-3274-43c8-afdf-de1cb4df5507"",
+                    ""path"": ""<Keyboard>/rightArrow"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""351a3ae4-42fd-4c61-8a13-69bc9f0700a5"",
+                    ""path"": ""<Keyboard>/space"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard"",
+                    ""action"": ""Jump"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""8d89f0c6-52f0-4819-a68d-29122bc0060a"",
+                    ""path"": ""<Gamepad>/buttonSouth"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Gamepad"",
+                    ""action"": ""Jump"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""ce464018-a481-42d4-93d7-c33dbe659282"",
+                    ""path"": ""<Keyboard>/x"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard"",
+                    ""action"": ""Dash"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""6f807831-7302-4e69-b80c-d0eb54978635"",
+                    ""path"": ""<Gamepad>/buttonWest"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Gamepad"",
+                    ""action"": ""Dash"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                }
+            ]
+        }
+    ],
+    ""controlSchemes"": [
+        {
+            ""name"": ""Keyboard"",
+            ""bindingGroup"": ""Keyboard"",
+            ""devices"": [
+                {
+                    ""devicePath"": ""<Keyboard>"",
+                    ""isOptional"": false,
+                    ""isOR"": false
+                }
+            ]
+        },
+        {
+            ""name"": ""Gamepad"",
+            ""bindingGroup"": ""Gamepad"",
+            ""devices"": [
+                {
+                    ""devicePath"": ""<Gamepad>"",
+                    ""isOptional"": false,
+                    ""isOR"": false
+                }
+            ]
+        }
+    ]
+}");
+        // Player
+        m_Player = asset.FindActionMap("Player", throwIfNotFound: true);
+        m_Player_Move = m_Player.FindAction("Move", throwIfNotFound: true);
+        m_Player_Jump = m_Player.FindAction("Jump", throwIfNotFound: true);
+        m_Player_Dash = m_Player.FindAction("Dash", throwIfNotFound: true);
+    }
+
+    public void Dispose()
+    {
+        UnityEngine.Object.Destroy(asset);
+    }
+
+    public InputBinding? bindingMask
+    {
+        get => asset.bindingMask;
+        set => asset.bindingMask = value;
+    }
+
+    public ReadOnlyArray<InputDevice>? devices
+    {
+        get => asset.devices;
+        set => asset.devices = value;
+    }
+
+    public ReadOnlyArray<InputControlScheme> controlSchemes => asset.controlSchemes;
+
+    public bool Contains(InputAction action)
+    {
+        return asset.Contains(action);
+    }
+
+    public IEnumerator<InputAction> GetEnumerator()
+    {
+        return asset.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public void Enable()
+    {
+        asset.Enable();
+    }
+
+    public void Disable()
+    {
+        asset.Disable();
+    }
+
+    // Player
+    private readonly InputActionMap m_Player;
+    private IPlayerActions m_PlayerActionsCallbackInterface;
+    private readonly InputAction m_Player_Move;
+    private readonly InputAction m_Player_Jump;
+    private readonly InputAction m_Player_Dash;
+    public struct PlayerActions
+    {
+        private @PlayerInput m_Wrapper;
+        public PlayerActions(@PlayerInput wrapper) { m_Wrapper = wrapper; }
+        public InputAction @Move => m_Wrapper.m_Player_Move;
+        public InputAction @Jump => m_Wrapper.m_Player_Jump;
+        public InputAction @Dash => m_Wrapper.m_Player_Dash;
+        public InputActionMap Get() { return m_Wrapper.m_Player; }
+        public void Enable() { Get().Enable(); }
+        public void Disable() { Get().Disable(); }
+        public bool enabled => Get().enabled;
+        public static implicit operator InputActionMap(PlayerActions set) { return set.Get(); }
+        public void SetCallbacks(IPlayerActions instance)
+        {
+            if (m_Wrapper.m_PlayerActionsCallbackInterface != null)
+            {
+                @Move.started -= m_Wrapper.m_PlayerActionsCallbackInterface.OnMove;
+                @Move.performed -= m_Wrapper.m_PlayerActionsCallbackInterface.OnMove;
+                @Move.canceled -= m_Wrapper.m_PlayerActionsCallbackInterface.OnMove;
+                @Jump.started -= m_Wrapper.m_PlayerActionsCallbackInterface.OnJump;
+                @Jump.performed -= m_Wrapper.m_PlayerActionsCallbackInterface.OnJump;
+                @Jump.canceled -= m_Wrapper.m_PlayerActionsCallbackInterface.OnJump;
+                @Dash.started -= m_Wrapper.m_PlayerActionsCallbackInterface.OnDash;
+                @Dash.performed -= m_Wrapper.m_PlayerActionsCallbackInterface.OnDash;
+                @Dash.canceled -= m_Wrapper.m_PlayerActionsCallbackInterface.OnDash;
+            }
+            m_Wrapper.m_PlayerActionsCallbackInterface = instance;
+            if (instance != null)
+            {
+                @Move.started += instance.OnMove;
+                @Move.performed += instance.OnMove;
+                @Move.canceled += instance.OnMove;
+                @Jump.started += instance.OnJump;
+                @Jump.performed += instance.OnJump;
+                @Jump.canceled += instance.OnJump;
+                @Dash.started += instance.OnDash;
+                @Dash.performed += instance.OnDash;
+                @Dash.canceled += instance.OnDash;
+            }
+        }
+    }
+    public PlayerActions @Player => new PlayerActions(this);
+    private int m_KeyboardSchemeIndex = -1;
+    public InputControlScheme KeyboardScheme
+    {
+        get
+        {
+            if (m_KeyboardSchemeIndex == -1) m_KeyboardSchemeIndex = asset.FindControlSchemeIndex("Keyboard");
+            return asset.controlSchemes[m_KeyboardSchemeIndex];
+        }
+    }
+    private int m_GamepadSchemeIndex = -1;
+    public InputControlScheme GamepadScheme
+    {
+        get
+        {
+            if (m_GamepadSchemeIndex == -1) m_GamepadSchemeIndex = asset.FindControlSchemeIndex("Gamepad");
+            return asset.controlSchemes[m_GamepadSchemeIndex];
+        }
+    }
+    public interface IPlayerActions
+    {
+        void OnMove(InputAction.CallbackContext context);
+        void OnJump(InputAction.CallbackContext context);
+        void OnDash(InputAction.CallbackContext context);
+    }
+}

--- a/Assets/Input/PlayerInput.cs.meta
+++ b/Assets/Input/PlayerInput.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8b0461c751ec0c449d65420e9b80003
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Input/PlayerInput.inputactions
+++ b/Assets/Input/PlayerInput.inputactions
@@ -1,0 +1,182 @@
+{
+    "name": "PlayerInput",
+    "maps": [
+        {
+            "name": "Player",
+            "id": "36e029b3-1b1a-433b-8e49-434a71c5cabf",
+            "actions": [
+                {
+                    "name": "Move",
+                    "type": "Value",
+                    "id": "2b152bf1-0e2b-46a2-9880-4c96c9881a59",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "Jump",
+                    "type": "Button",
+                    "id": "14049dc8-85b7-41c6-aeb4-8d118b697b33",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "Dash",
+                    "type": "Button",
+                    "id": "59c3dfb9-cbc2-4900-b552-6d02dc55acac",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": ""
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "618146dd-3f6e-44c4-bdd2-26b20f03665b",
+                    "path": "<Gamepad>/leftStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "7b7d8eee-69c4-4456-9535-d41344cf6824",
+                    "path": "<Joystick>/stick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "Arrows",
+                    "id": "d14f03b1-52bc-4d72-9983-7700e1fcc36a",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "b0568dd2-7771-4df9-b7c7-7780b9b0d015",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "5f05f417-396c-4014-89b8-6ecb828cfa4f",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "9465263f-c3ac-42e0-8158-df9bed5b0023",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "61601d4f-3274-43c8-afdf-de1cb4df5507",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "351a3ae4-42fd-4c61-8a13-69bc9f0700a5",
+                    "path": "<Keyboard>/space",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "8d89f0c6-52f0-4819-a68d-29122bc0060a",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ce464018-a481-42d4-93d7-c33dbe659282",
+                    "path": "<Keyboard>/x",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Dash",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "6f807831-7302-4e69-b80c-d0eb54978635",
+                    "path": "<Gamepad>/buttonWest",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Dash",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        }
+    ],
+    "controlSchemes": [
+        {
+            "name": "Keyboard",
+            "bindingGroup": "Keyboard",
+            "devices": [
+                {
+                    "devicePath": "<Keyboard>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        },
+        {
+            "name": "Gamepad",
+            "bindingGroup": "Gamepad",
+            "devices": [
+                {
+                    "devicePath": "<Gamepad>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        }
+    ]
+}

--- a/Assets/Input/PlayerInput.inputactions.meta
+++ b/Assets/Input/PlayerInput.inputactions.meta
@@ -1,0 +1,14 @@
+fileFormatVersion: 2
+guid: aa1f20dbdd82f204db05ed0477246b56
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 8404be70184654265930450def6a9037, type: 3}
+  generateWrapperCode: 1
+  wrapperCodePath: 
+  wrapperClassName: 
+  wrapperCodeNamespace: 

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -299,16 +299,16 @@ MonoBehaviour:
   groundDeceleration: 120
   jumpHeight: 4
   wallDeceleration: 0.8
-  DrawDebugRays: 1
-  WallsRayLength: 0.795
-  LeftWallCheck: {fileID: 6305144039226606819}
-  RightWallCheck: {fileID: 4800326651393294273}
-  WallsLayerMask:
-    serializedVersion: 2
-    m_Bits: 512
   dashDuration: 0.15
   dashSpeed: 60
   dashAcceleration: 500
+  drawDebugRays: 1
+  wallsRayLength: 1.6
+  leftWallCheck: {fileID: 6305144039226606819}
+  rightWallCheck: {fileID: 4800326651393294273}
+  wallsLayerMask:
+    serializedVersion: 2
+    m_Bits: 512
   OnJump:
     m_PersistentCalls:
       m_Calls:

--- a/Assets/Scenes/Prototype.unity
+++ b/Assets/Scenes/Prototype.unity
@@ -168,9 +168,16 @@ MonoBehaviour:
   m_ExcludedPropertiesInInspector:
   - m_Script
   m_LockStageInInspector: 
+  m_ValidatingStreamVersion: 20170927
+  m_OnValidateCalled: 1
   m_StreamingVersion: 20170927
   m_Priority: 10
   m_StandbyUpdate: 2
+  mExtensions: []
+  <PreviousStateIsValid>k__BackingField: 1
+  mSlaveStatusUpdated: 1
+  m_parentVcam: {fileID: 0}
+  m_QueuePriority: 10
   m_LookAt: {fileID: 0}
   m_Follow: {fileID: 1705286002}
   m_Lens:
@@ -179,6 +186,9 @@ MonoBehaviour:
     NearClipPlane: 0.3
     FarClipPlane: 1000
     Dutch: 0
+    <Orthographic>k__BackingField: 1
+    <SensorSize>k__BackingField: {x: 1.7775061, y: 1}
+    <IsPhysicalCamera>k__BackingField: 0
     LensShift: {x: 0, y: 0}
   m_Transitions:
     m_BlendHint: 0
@@ -186,8 +196,14 @@ MonoBehaviour:
     m_OnCameraLive:
       m_PersistentCalls:
         m_Calls: []
+      m_CallsDirty: 0
   m_LegacyBlendHint: 0
+  <UserIsDragging>k__BackingField: 0
+  m_ComponentPipeline:
+  - {fileID: 1014278972}
   m_ComponentOwner: {fileID: 1014278971}
+  mCachedLookAtTarget: {fileID: 0}
+  mCachedLookAtTargetVcam: {fileID: 0}
 --- !u!1 &240113554
 GameObject:
   m_ObjectHideFlags: 0
@@ -466,18 +482,21 @@ MonoBehaviour:
     m_Style: 1
     m_Time: 2
     m_CustomCurve:
-      serializedVersion: 2
       m_Curve: []
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
   m_CustomBlends: {fileID: 0}
+  m_OutputCamera: {fileID: 519420031}
   m_CameraCutEvent:
     m_PersistentCalls:
       m_Calls: []
+    m_CallsDirty: 0
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
+    m_CallsDirty: 0
+  mNextFrameId: 1
 --- !u!20 &519420031
 Camera:
   m_ObjectHideFlags: 0
@@ -529,7 +548,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -7.34, y: -1.2695867, z: -10}
+  m_LocalPosition: {x: -7.34, y: -1.2695863, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1250611255}
@@ -743,6 +762,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6ad980451443d70438faac0bc6c235a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_vcamOwner: {fileID: 146521441}
+  mCachedFollowTarget: {fileID: 1705286002}
+  mCachedFollowTargetVcam: {fileID: 0}
+  mCachedLookAtTarget: {fileID: 0}
+  mCachedLookAtTargetVcam: {fileID: 0}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 10
   m_LookaheadIgnoreY: 0
@@ -772,6 +796,30 @@ MonoBehaviour:
   m_MaximumFOV: 60
   m_MinimumOrthoSize: 1
   m_MaximumOrthoSize: 5000
+  m_PreviousCameraPosition: {x: -7.34, y: -1.2695863, z: -10}
+  <TrackedPoint>k__BackingField: {x: -7.34, y: -1.2695863, z: 0}
+  <InheritingPosition>k__BackingField: 0
+  m_prevFOV: 8
+  <LastBounds>k__BackingField:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  <LastBoundsMatrix>k__BackingField:
+    e00: 0
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 0
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 0
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 0
 --- !u!114 &1014278973
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -1849,7 +1897,7 @@ PrefabInstance:
     - target: {fileID: 476714754079885257, guid: 8390b5fc7d470ed45a0998c3a9731d21,
         type: 3}
       propertyPath: WallsRayLength
-      value: 0.795
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 476714754079885257, guid: 8390b5fc7d470ed45a0998c3a9731d21,
         type: 3}
@@ -1884,7 +1932,7 @@ PrefabInstance:
     - target: {fileID: 4738642859323635689, guid: 8390b5fc7d470ed45a0998c3a9731d21,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.2695867
+      value: -1.2695866
       objectReference: {fileID: 0}
     - target: {fileID: 4738642859323635689, guid: 8390b5fc7d470ed45a0998c3a9731d21,
         type: 3}

--- a/Assets/Scripts/Music/BeatHooker.cs
+++ b/Assets/Scripts/Music/BeatHooker.cs
@@ -1,3 +1,5 @@
+#pragma warning disable 0649
+
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -12,8 +14,7 @@ public class BeatHooker : MonoBehaviour
         [ConditionalField("AllSong", true)] public float From;
         [ConditionalField("AllSong", true)] public float To;
 
-        [Space()] [Header("Events")]
-        public UnityEvent OnStep;
+        [Space()] [Header("Events")] public UnityEvent OnStep;
         public UnityEvent OnEveryTwoStep;
         public UnityEvent OnFirstAndThirdStep;
         public UnityEvent OnHalfBeat;
@@ -86,25 +87,35 @@ public class BeatHooker : MonoBehaviour
 
     private void Start()
     {
-        foreach (var handler in _handlers)
+        var synchronizer = FindObjectOfType<SongSynchronizer>();
+        if (synchronizer != null)
         {
-            FindObjectOfType<SongSynchronizer>().Step += handler.Value[BeatEvents.Step];
-            FindObjectOfType<SongSynchronizer>().EveryTwoStep += handler.Value[BeatEvents.EveryTwoStep];
-            FindObjectOfType<SongSynchronizer>().FirstAndThirdStep += handler.Value[BeatEvents.FirstAndThirdStep];
-            FindObjectOfType<SongSynchronizer>().HalfBeat += handler.Value[BeatEvents.HalfBeat];
-            FindObjectOfType<SongSynchronizer>().Beat += handler.Value[BeatEvents.Beat];
+            foreach (var handler in _handlers)
+            {
+                synchronizer.Step += handler.Value[BeatEvents.Step];
+                synchronizer.EveryTwoStep += handler.Value[BeatEvents.EveryTwoStep];
+                synchronizer.FirstAndThirdStep += handler.Value[BeatEvents.FirstAndThirdStep];
+                synchronizer.HalfBeat += handler.Value[BeatEvents.HalfBeat];
+                synchronizer.Beat += handler.Value[BeatEvents.Beat];
+            }
         }
     }
 
     private void OnDestroy()
     {
-        foreach (var handler in _handlers)
+        var synchronizer = FindObjectOfType<SongSynchronizer>();
+        if (synchronizer != null)
         {
-            FindObjectOfType<SongSynchronizer>().Step -= handler.Value[BeatEvents.Step];
-            FindObjectOfType<SongSynchronizer>().EveryTwoStep -= handler.Value[BeatEvents.EveryTwoStep];
-            FindObjectOfType<SongSynchronizer>().FirstAndThirdStep -= handler.Value[BeatEvents.FirstAndThirdStep];
-            FindObjectOfType<SongSynchronizer>().HalfBeat -= handler.Value[BeatEvents.HalfBeat];
-            FindObjectOfType<SongSynchronizer>().Beat -= handler.Value[BeatEvents.Beat];
+            {
+                foreach (var handler in _handlers)
+                {
+                    synchronizer.Step -= handler.Value[BeatEvents.Step];
+                    synchronizer.EveryTwoStep -= handler.Value[BeatEvents.EveryTwoStep];
+                    synchronizer.FirstAndThirdStep -= handler.Value[BeatEvents.FirstAndThirdStep];
+                    synchronizer.HalfBeat -= handler.Value[BeatEvents.HalfBeat];
+                    synchronizer.Beat -= handler.Value[BeatEvents.Beat];
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/Music/SongSynchronizer.cs
+++ b/Assets/Scripts/Music/SongSynchronizer.cs
@@ -1,4 +1,6 @@
-﻿﻿using System;
+﻿#pragma warning disable 0649
+
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using Rythmformer;

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,6 +6,7 @@
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.ide.rider": "1.1.4",
     "com.unity.ide.vscode": "1.1.4",
+    "com.unity.inputsystem": "1.0.0-preview.4",
     "com.unity.render-pipelines.universal": "7.1.8",
     "com.unity.test-framework": "1.1.9",
     "com.unity.textmeshpro": "2.0.1",

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -8,4 +8,6 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Prototype.unity
     guid: 2cda990e2423bbf4892e6590ba056729
-  m_configObjects: {}
+  m_configObjects:
+    com.unity.input.settings: {fileID: 11400000, guid: 490d09f96a57bf643840772a85a17873,
+      type: 2}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -640,6 +640,6 @@ PlayerSettings:
   projectName: 
   organizationId: 
   cloudEnabled: 0
-  enableNativePlatformBackendsForNewInputSystem: 0
+  enableNativePlatformBackendsForNewInputSystem: 1
   disableOldInputManagerSupport: 0
   legacyClampBlendShapeWeights: 0


### PR DESCRIPTION
## ❓ Description
<!-- Quand tu peux, décris ce que fais ta PR, comme ça on a déjà une idée du contexte et de ce que cette dernière apporte -->
Ajout du support pour le nouveau système d'Input de Unity.
On supporte donc désormais les manettes et le clavier. Pour voir les détails du mapping, il faut aller dans le dossier `Assets/Input`. On y trouve le fichier d'input pour le player et sa classe C# qui est **autogénérée** (à ne pas modifier à la main donc).

La pour tester j'ai mis en gros le bouton `South` pour le Gamepad (ce qui correspond à A sur Xbox, X sur PS4 enfin vous avez capté je pense) et le bouton `West` pour le dash, et sur clavier j'ai laissé ce que @mineraux avait mis par défaut (`X`)

## 📋 Spécifications techniques
<!-- Globalement, décris ce que tu as fait dans cette PR dans une liste à puce claire et concise (ici tu peux mettre des détails très techniques) -->
- [x] Clean un peu du code de `CharacterController`
	- [x] Déplacement de méthodes dans des régions C# pour plus de clarté quand on déplie / plie le contenu du fichier
- [x] Ajout du package d'input system d'Unity (je ne sais pas du coup si quand vous pullerez faut faire un genre de `npm install` ou bien Unity va automatiquement installer les nouveaux paquets)